### PR TITLE
Sound Effect looping fix for Android

### DIFF
--- a/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSound.java
+++ b/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSound.java
@@ -63,7 +63,7 @@ public class SpatializedSound<T> implements Poolable {
 		looping = false;
 	}
 
-	public long initialize(Sound sound, float duration, T position, float volume, float pitch, float panning) {
+	public long initialize(Sound sound, boolean looping, float duration, T position, float volume, float pitch, float panning) {
 		this.sound = sound;
 		this.duration = duration;
 
@@ -72,8 +72,11 @@ public class SpatializedSound<T> implements Poolable {
 		this.elapsed = 0f;
 
 		running = true;
-
-		return this.id = sound.play(this.volume = volume, this.pitch = pitch, this.pan = panning);
+		if (looping) {
+			return this.id = sound.loop(this.volume = volume, this.pitch = pitch, this.pan = panning);
+		} else {
+			return this.id = sound.play(this.volume = volume, this.pitch = pitch, this.pan = panning);
+		}
 	}
 
 	public long getId() {

--- a/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
+++ b/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
@@ -80,6 +80,7 @@ public class SpatializedSoundPlayer<T> {
 			pool.free(instance);
 			Gdx.app.error("gdx-sfx", "Couldn't play sound " + sound);
 		} else {
+			instance.setLooping(true);
 			spatializer.spatialize(instance, this.volume);
 
 			sounds.put(id, instance);

--- a/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
+++ b/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
@@ -74,13 +74,12 @@ public class SpatializedSoundPlayer<T> {
 		
 		Spatializer<T> spatializer = this.spatializer;
 		
-		long id = instance.initialize(sound, duration, position, 0f, pitch, 0f);
+		long id = instance.initialize(sound, looping, duration, position, 0f, pitch, 0f);
 
 		if (id == -1) {
 			pool.free(instance);
 			Gdx.app.error("gdx-sfx", "Couldn't play sound " + sound);
 		} else {
-			instance.setLooping(looping);
 			spatializer.spatialize(instance, this.volume);
 
 			sounds.put(id, instance);

--- a/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
+++ b/core/src/main/java/net/spookygames/gdx/sfx/spatial/SpatializedSoundPlayer.java
@@ -32,7 +32,7 @@ import com.badlogic.gdx.utils.Pool;
 import net.spookygames.gdx.sfx.SfxSound;
 
 public class SpatializedSoundPlayer<T> {
-	
+
 	private final Pool<SpatializedSound<T>> pool = new Pool<SpatializedSound<T>>() {
 		@Override
 		protected SpatializedSound<T> newObject() {
@@ -41,7 +41,7 @@ public class SpatializedSoundPlayer<T> {
 	};
 
 	private final LongMap<SpatializedSound<T>> sounds = new LongMap<SpatializedSound<T>>();
-	
+
 	private Spatializer<T> spatializer;
 
 	private float volume = 1f;
@@ -69,29 +69,30 @@ public class SpatializedSoundPlayer<T> {
 	public long play(T position, SfxSound sound, float pitch, boolean looping) {
 
 		SpatializedSound<T> instance = pool.obtain();
-		
+
 		float duration = sound.getDuration();
-		
+
 		Spatializer<T> spatializer = this.spatializer;
-		
-		long id = instance.initialize(sound, looping, duration, position, 0f, pitch, 0f);
+
+		long id = instance.initialize(sound, looping, duration, position, 0f,
+				pitch, 0f);
 
 		if (id == -1) {
 			pool.free(instance);
 			Gdx.app.error("gdx-sfx", "Couldn't play sound " + sound);
 		} else {
-			instance.setLooping(true);
+			instance.setLooping(looping);
 			spatializer.spatialize(instance, this.volume);
 
 			sounds.put(id, instance);
 		}
-		
+
 		return id;
 	}
 
 	public void update(float delta) {
 		Spatializer<T> spatializer = this.spatializer;
-		
+
 		Iterator<SpatializedSound<T>> iterator = sounds.values();
 		while (iterator.hasNext()) {
 			SpatializedSound<T> instance = iterator.next();


### PR DESCRIPTION
On my Huawei P8 running Android 5.0.1 the spatialized sound effect looping does not work. The fix was straightforward to not use `setLooping()` but `loop()`

EDIT: Turns out, removing setLooping breaks looping on desktop, so now its both setLooping and loop(). Tested on both android and desktop