### PR TITLE
Allow sounds to have their own playback volumes

### DIFF
--- a/core/src/main/java/games/spooky/gdx/sfx/spatial/FadingSpatializedSound.java
+++ b/core/src/main/java/games/spooky/gdx/sfx/spatial/FadingSpatializedSound.java
@@ -43,8 +43,8 @@ public class FadingSpatializedSound<T> extends SpatializedSound<T> {
 		realVolume = 0;
 	}
 
-	public long initialize(Sound sound, float duration, T position, float volume, float pitch, float panning, float fadeTime, boolean fadeIn) {
-		long id = super.initialize(sound, duration, position, volume, pitch, panning);
+	public long initialize(Sound sound, float duration, T position, float volume, float pitch, float panning, float intrinsicVolume, float fadeTime, boolean fadeIn) {
+		long id = super.initialize(sound, duration, position, volume, pitch, panning, intrinsicVolume);
 
 		this.fadeTime = fadeTime;
 
@@ -59,7 +59,8 @@ public class FadingSpatializedSound<T> extends SpatializedSound<T> {
 		return fadeProgress > -1;
 	}
 
-	public void setVolume(float volume) {
+	@Override
+    public void setVolume(float volume) {
 		// setup correct target volume we got from spatialize
 		if (elapsed == 0 && fadeProgress > -1) {
 			realVolume = volume;
@@ -68,6 +69,7 @@ public class FadingSpatializedSound<T> extends SpatializedSound<T> {
 		}
 	}
 
+    @Override
 	public void setPan(float pan, float volume) {
 		// setup correct target volume we got from spatialize
 		if (elapsed == 0 && fadeProgress > -1) {

--- a/core/src/main/java/games/spooky/gdx/sfx/spatial/FadingSpatializedSoundPlayer.java
+++ b/core/src/main/java/games/spooky/gdx/sfx/spatial/FadingSpatializedSoundPlayer.java
@@ -46,13 +46,17 @@ public class FadingSpatializedSoundPlayer<T> extends SpatializedSoundPlayer<T> {
 	}
 
 	public long play(T position, SfxSound sound, float pitch, boolean looping, boolean fadeIn) {
+	    return play(position, sound, 1f, pitch, looping, fadeIn);
+	}
+	
+	public long play(T position, SfxSound sound, float intrinsicVolume, float pitch, boolean looping, boolean fadeIn) {
 		FadingSpatializedSound<T> instance = (FadingSpatializedSound<T>) pool.obtain();
 
 		float duration = sound.getDuration();
 
 		Spatializer<T> spatializer = this.spatializer;
 
-		long id = instance.initialize(sound, duration, position, 0f, pitch, 0f,	fadeTime, fadeIn);
+		long id = instance.initialize(sound, duration, position, 0f, pitch, 0f,	intrinsicVolume, fadeTime, fadeIn);
 
 		if (id == -1) {
 			pool.free(instance);
@@ -67,6 +71,7 @@ public class FadingSpatializedSoundPlayer<T> extends SpatializedSoundPlayer<T> {
 		return id;
 	}
 
+	@Override
 	public void update(float delta) {
 		Spatializer<T> spatializer = this.spatializer;
 
@@ -83,6 +88,7 @@ public class FadingSpatializedSoundPlayer<T> extends SpatializedSoundPlayer<T> {
 		}
 	}
 	
+	@Override
 	public void stop(long id) {
 		SpatializedSound<T> sound = sounds.get(id);
 

--- a/core/src/main/java/games/spooky/gdx/sfx/spatial/SpatializedSoundPlayer.java
+++ b/core/src/main/java/games/spooky/gdx/sfx/spatial/SpatializedSoundPlayer.java
@@ -63,17 +63,24 @@ public class SpatializedSoundPlayer<T> {
 	}
 
 	public long play(T position, SfxSound sound) {
-		return play(position, sound, 1f, false);
+		return play(position, sound, 1f, 1f, false);
+	}
+	
+	public long play(T position, SfxSound sound, float pitch, boolean looping) {
+	    return play(position, sound, 1f, pitch, looping);
 	}
 
-	public long play(T position, SfxSound sound, float pitch, boolean looping) {
+	/**
+	 * @param intrinsicVolume intrinsic volume of this sound, set at init, and multiples all subsequent volumes
+	 */
+	public long play(T position, SfxSound sound, float intrinsicVolume, float pitch, boolean looping) {
 		SpatializedSound<T> instance = pool.obtain();
 
 		float duration = sound.getDuration();
 
 		Spatializer<T> spatializer = this.spatializer;
 
-		long id = instance.initialize(sound, duration, position, 0f, pitch, 0f);
+		long id = instance.initialize(sound, duration, position, 0f, pitch, 0f, intrinsicVolume);
 
 		if (id == -1) {
 			pool.free(instance);


### PR DESCRIPTION
First thank you so much for this project and making it open source! It's awesome.

I found that with the sound spatializer, the volume is always set based on the volume of the originally playing sound.

i.e. if I wanted to play
- Sound X at 100%
- Sound Y at 20%

There was no way to do this with spatialization, e.g. if after spatialization all sounds should be at 50%, then I couldn't get
- Sound X at 100% * 50% = 50%
- Sound Y at 20% * 50% = 10%

This commit adds support for playing sounds with "intrinsic" volumes; that is, any spatializing/panning volume change is multiplied by the intrinsic volume of each sound. This value is provided by a new parameter `intrinsicVolume` to `SpatializedSoundPlayer#play(...)`.

I _think_ this works, and I have tested it on my own game.

(I had difficulty getting Jitpack to build this as a deployable .jar 😂 I'm testing it by extending my build.gradle in my libgdx project with the following, [using a different branch](https://github.com/soundasleep/gdx-sfx/tree/intrinsic-volumes) that turns off Android/desktop building:)

```gradle
project(:core) {
  dependencies {
    // Forked: implementation "games.spooky.gdx:gdx-sfx:$gdxSfxVersion"
    implementation "com.github.soundasleep:gdx-sfx:intrinsic-volumes-SNAPSHOT" // this ONLY has the core project, not android, desktop, etc
  }
}

project(:desktop) { 
  dependencies {
    // ...
    implementation("games.spooky.gdx:gdx-sfx-desktop:$gdxSfxVersion") {        
      exclude group: "games.spooky.gdx", module: "gdx-sfx" // so that this 
    }
  }
}
```
